### PR TITLE
Enable tests

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+paho-socket (0.0.3-2) stable; urgency=medium
+
+  * Enable tests, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 10 Jul 2024 14:10:00 +0400
+
 paho-socket (0.0.3-1) stable; urgency=medium
 
   * Fix homepage in debian/control; no functional changes

--- a/debian/control
+++ b/debian/control
@@ -2,10 +2,18 @@ Source: paho-socket
 Section: admin
 Priority: optional
 Maintainer: Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>
-Build-Depends: debhelper (>= 10), dh-python, python3-all, python3-setuptools, pkg-config, python3-paho-mqtt (= 1.5.1-1)
+Build-Depends: debhelper (>= 10),
+               dh-python,
+               python3-all,
+               python3-setuptools,
+               pkg-config,
+               python3-paho-mqtt (= 1.5.1-1),
+               python3-pytest,
+               python3-tomli,
+               mosquitto
 Standards-Version: 4.5.0
 Vcs-Git: https://github.com/wirenboard/paho-socket
-Homepage: https://github.com/mgetka/paho-socket
+Homepage: https://github.com/wirenboard/paho-socket
 
 Package: python3-paho-socket
 Section: python

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,7 @@ import os.path
 import signal
 import socket
 import subprocess
-from distutils.version import LooseVersion
+from packaging.version import Version
 from time import sleep
 
 import pytest
@@ -38,8 +38,8 @@ def broker():
     for line in ret.stdout.decode().splitlines():
         if "version" in line:
             *_, raw_version = line.rpartition(" ")
-            version = LooseVersion(raw_version)
-            if version < "2":
+            version = Version(raw_version)
+            if version < Version("2"):
                 pytest.skip("Mosquitto >=2.0.0 is required for the tests.")
             break
 


### PR DESCRIPTION
```sh
   dh_auto_test -i -O--buildsystem=pybuild
I: pybuild base:232: cd /<<PKGBUILDDIR>>/.pybuild/cpython3_3.9_paho-socket/build; python3.9 -m pytest test
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.1.2, pluggy-0.13.0
rootdir: /<<PKGBUILDDIR>>, configfile: pyproject.toml
plugins: testinfra-8.1.0
collected 8 items

test/test_client.py .......                                              [ 87%]
test/test_integration.py .                                               [100%]

============================== 8 passed in 0.57s ===============================
```