### PR TITLE
Support for paho.mqtt.python v2.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+paho-socket (0.0.3-3) stable; urgency=medium
+
+  * Support for paho.mqtt.python v2.0
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 28 Mar 2025 14:10:00 +0400
+
 paho-socket (0.0.3-2) stable; urgency=medium
 
   * Enable tests, no functional changes

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 10),
                python3-all,
                python3-setuptools,
                pkg-config,
-               python3-paho-mqtt (= 1.5.1-1),
+               python3-paho-mqtt (<<2.1.0),
                python3-pytest,
                python3-tomli,
                mosquitto
@@ -18,5 +18,5 @@ Homepage: https://github.com/wirenboard/paho-socket
 Package: python3-paho-socket
 Section: python
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, python3-packaging, python3-paho-mqtt (= 1.5.1-1)
+Depends: ${python3:Depends}, ${misc:Depends}, python3-packaging, python3-paho-mqtt (<<2.1.0)
 Description: Thin layer built on top of paho-mqtt allowing for connections with unix socket brokers

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 10),
                python3-all,
                python3-setuptools,
                pkg-config,
-               python3-paho-mqtt (<<2.1.0),
+               python3-paho-mqtt (<< 2.1.0),
                python3-pytest,
                python3-tomli,
                mosquitto
@@ -18,5 +18,5 @@ Homepage: https://github.com/wirenboard/paho-socket
 Package: python3-paho-socket
 Section: python
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, python3-packaging, python3-paho-mqtt (<<2.1.0)
+Depends: ${python3:Depends}, ${misc:Depends}, python3-packaging, python3-paho-mqtt (<< 2.1.0)
 Description: Thin layer built on top of paho-mqtt allowing for connections with unix socket brokers

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ lazy-object-proxy==1.4.3
 mccabe==0.6.1
 mypy-extensions==0.4.3
 packaging==20.8
-paho-mqtt==1.5.1
+paho-mqtt<2.1.0
 pathspec==0.8.1
 pluggy==0.13.1
 py==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-paho-mqtt==1.5.1
+paho-mqtt<2.1.0

--- a/src/paho_socket/client.py
+++ b/src/paho_socket/client.py
@@ -1,7 +1,12 @@
 """Socket capable client extension implementation."""
 import socket
 
+import paho.mqtt
 from paho.mqtt import client as _client
+if paho.mqtt.__version__[0] > '1':
+    mqtt_cs_connect_async = _client._ConnectionState.MQTT_CS_CONNECT_ASYNC
+else:
+    mqtt_cs_connect_async = _client.mqtt_cs_connect_async
 
 
 class Client(_client.Client):
@@ -10,6 +15,8 @@ class Client(_client.Client):
     # pylint: disable=redefined-outer-name,too-many-instance-attributes
 
     def __init__(self, *args, **kwargs):
+        if paho.mqtt.__version__[0] > '1':
+            kwargs["callback_api_version"] = _client.CallbackAPIVersion.VERSION1
         super().__init__(*args, **kwargs)
         self._socket = None
 
@@ -82,7 +89,7 @@ class Client(_client.Client):
             clean_start
         )
         self._connect_properties = properties
-        self._state = _client.mqtt_cs_connect_async
+        self._state = mqtt_cs_connect_async
 
         # We need to pas some junk data here, since for some unknown reason reconnect checks
         # validity of those field on each reconnect, even though they are already validated by

--- a/src/paho_socket/client.py
+++ b/src/paho_socket/client.py
@@ -3,7 +3,7 @@ import socket
 
 import paho.mqtt
 from paho.mqtt import client as _client
-if paho.mqtt.__version__[0] > '1':
+if paho.mqtt.__version__.startswith("2"):
     mqtt_cs_connect_async = _client._ConnectionState.MQTT_CS_CONNECT_ASYNC
 else:
     mqtt_cs_connect_async = _client.mqtt_cs_connect_async
@@ -15,7 +15,7 @@ class Client(_client.Client):
     # pylint: disable=redefined-outer-name,too-many-instance-attributes
 
     def __init__(self, *args, **kwargs):
-        if paho.mqtt.__version__[0] > '1':
+        if paho.mqtt.__version__.startswith("2"):
             kwargs["callback_api_version"] = _client.CallbackAPIVersion.VERSION1
         super().__init__(*args, **kwargs)
         self._socket = None

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -23,7 +23,7 @@ def test_communication(broker):
         if msg.payload == b"socket_message":
             recv_socket_message = True
 
-    if paho.mqtt.__version__[0] > '1':
+    if paho.mqtt.__version__.startswith("2"):
         tcp = mqttClient.Client(mqttClient.CallbackAPIVersion.VERSION1)
     else:
         tcp = mqttClient.Client()

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,6 +1,7 @@
 from time import sleep
 
-import paho.mqtt.client
+import paho.mqtt
+import paho.mqtt.client as mqttClient
 import pytest
 
 import paho_socket
@@ -22,7 +23,10 @@ def test_communication(broker):
         if msg.payload == b"socket_message":
             recv_socket_message = True
 
-    tcp = paho.mqtt.client.Client()
+    if paho.mqtt.__version__[0] > '1':
+        tcp = mqttClient.Client(mqttClient.CallbackAPIVersion.VERSION1)
+    else:
+        tcp = mqttClient.Client()
     tcp.on_message = tcp_message
     tcp.connect("127.0.0.1", 8520)
 


### PR DESCRIPTION
В debian trixie сейчас python3-paho-mqtt 2.0.0, когда завезут 2.1.0 эта либа больше будет ненужна, так как в 2.1.0 добавили поддержку unix сокетов из коробки.